### PR TITLE
GitHub Example plots and some standardization

### DIFF
--- a/_config_automation.yml
+++ b/_config_automation.yml
@@ -31,7 +31,13 @@ cran_googlesheet:
 
 ###### GitHub ######
 refresh-github: yes
-github_repos: [ fhdsl/metricminer, fhdsl/metricminer.org ]
+github_repos: [
+  fhdsl/metricminer,
+  fhdsl/metricminer.org,
+  fhdsl/metricminer-dashboard,
+  jhudsl/OTTR_Template,
+  jhudsl/OTTR_Template_Website
+  ]
 github_googlesheet:
 
 ###### Google Analytics ######

--- a/_config_automation.yml
+++ b/_config_automation.yml
@@ -33,7 +33,6 @@ cran_googlesheet:
 refresh-github: yes
 github_repos: [
   fhdsl/metricminer,
-  fhdsl/metricminer.org,
   fhdsl/metricminer-dashboard,
   jhudsl/OTTR_Template,
   jhudsl/OTTR_Template_Website

--- a/calendly.Rmd
+++ b/calendly.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "Calendly"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/calendly.Rmd
+++ b/calendly.Rmd
@@ -2,9 +2,9 @@
 title: "Calendly"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/calendly.Rmd
+++ b/calendly.Rmd
@@ -44,3 +44,13 @@ After you've set up authorization you'll need to check the following items in th
 refresh-calendly: yes
 calendly_googlesheet:
 ```
+
+## Customizing the data 
+
+In order to customize the data you are downloading from calendly you can modify the 
+`refresh-scripts/refresh-calendly.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 
+

--- a/citations.Rmd
+++ b/citations.Rmd
@@ -1,10 +1,10 @@
 ---
 title: "Citations"
-output: 
+output:
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -28,18 +28,18 @@ Here we show how to get the total counts per original paper:
 ```{r,message=FALSE}
 library(dplyr)
 # here we remove duplicates if there are any of the same titles of citing papers for each original paper and then get a count of the number of rows for each original paper (aka how many times it is cited)
-citations %>% 
-  distinct(original_paper, cite_titles, .keep_all = TRUE) %>% 
+citations %>%
+  distinct(original_paper, cite_titles, .keep_all = TRUE) %>%
   count(original_paper)
 ```
 
-## Data information 
+## Data information
 
 Column information:
 
 - `original_paper` shows papers that we have captured citation information about
 - `cite_titles` shows papers that cite the original paper
-- `links`column shows the link for the paper that cites the original paper (the `cite_titles` papers). 
+- `links`column shows the link for the paper that cites the original paper (the `cite_titles` papers).
 
 ```{r, message = FALSE}
 knitr::kable(citations)
@@ -50,8 +50,8 @@ knitr::kable(citations)
 1. Go to: https://scholar.google.com/scholar
 2. Search for the paper you are looking for the citation count.
 3. Then click the `Cited by ___` button below the title of the paper
-4. Copy and paste this in the `_config_automation.yml` file in the `citation_papers` section. 
-         
+4. Copy and paste this in the `_config_automation.yml` file in the `citation_papers` section.
+
 ```
 ###### Citations ######
 refresh-citations: yes
@@ -62,3 +62,13 @@ citation_googlesheet:
 ```
 - [ ] In the `config_automation.yml` file, make sure that `refresh-citations` is set to "yes".
 - [ ] Optionally, if you are saving data to google, specify a googlesheet ID in `citation_googlesheet` if you'd like the citation data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+
+## Customizing Citation Data 
+
+In order to customize the data you are downloading from Google Scholar you can modify the 
+`refresh-scripts/refresh-citations.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/citations.Rmd
+++ b/citations.Rmd
@@ -19,6 +19,16 @@ citations <- readr::read_tsv(file.path("metricminer_data", "citations", "citatio
 # citations <- googlesheets4::read_sheet(yaml$citations_googlesheet)
 ```
 
+Here we show how to get the total counts per original paper:
+
+```{r,message=FALSE}
+library(dplyr)
+# here we remove duplicates if there are any of the same titles of citing papers for each original paper and then get a count of the number of rows for each original paper (aka how many times it is cited)
+citations %>% 
+  distinct(original_paper, cite_titles, .keep_all = TRUE) %>% 
+  count(original_paper)
+```
+
 ## Data information 
 
 Column information:
@@ -29,16 +39,6 @@ Column information:
 
 ```{r, message = FALSE}
 knitr::kable(citations)
-```
-
-Here we show how to get the total counts per original paper:
-
-```{r,message=FALSE}
-library(dplyr)
-# here we remove duplicates if there are any of the same titles of citing papers for each original paper and then get a count of the number of rows for each original paper (aka how many times it is cited)
-citations %>% 
-  distinct(original_paper, cite_titles, .keep_all = TRUE) %>% 
-  count(original_paper)
 ```
 
 ## Setting up Citations

--- a/citations.Rmd
+++ b/citations.Rmd
@@ -19,6 +19,8 @@ citations <- readr::read_tsv(file.path("metricminer_data", "citations", "citatio
 # citations <- googlesheets4::read_sheet(yaml$citations_googlesheet)
 ```
 
+## Data information 
+
 Column information:
 
 - `original_paper` shows papers that we have captured citation information about

--- a/citations.Rmd
+++ b/citations.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "Citations"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/cran.Rmd
+++ b/cran.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "CRAN"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -18,15 +22,15 @@ cran <- readr::read_tsv(file.path("metricminer_data", "cran", "cran.tsv"))
 ## For google
 # cran <- googlesheets4::read_sheet(yaml$cran_googlesheet)
 ```
+
+Total CRAN downloads for all packages: 
+
 ```{r}
 cran %>% dplyr::summarize(download_total = sum(count))
 ```
-
+CRAN package downloads over time, summarized by month. 
 
 ```{r, message = FALSE}
-cran %>% dplyr::group_by(package) %>%
-   dplyr::summarize(download_total = sum(count))
-
 cran_stats <- cran %>%
   separate(date, into=c("year", "month name", "day"), sep = "-") %>%
   unite("Month", c("year", "month name"), sep='-', remove=TRUE) %>%  

--- a/cran.Rmd
+++ b/cran.Rmd
@@ -6,18 +6,16 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ## Preview
 
-```{r}
+```{r, echo = FALSE, hide = TRUE, message = FALSE}
 library(tidyverse)
-```
 
-```{r, echo = FALSE, hide = TRUE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 
 ## For github
 cran <- readr::read_tsv(file.path("metricminer_data", "cran", "cran.tsv"))
 
-## For google 
+## For google
 # cran <- googlesheets4::read_sheet(yaml$cran_googlesheet)
 ```
 ```{r}
@@ -25,19 +23,19 @@ cran %>% dplyr::summarize(download_total = sum(count))
 ```
 
 
-```{r}
+```{r, message = FALSE}
 cran %>% dplyr::group_by(package) %>%
    dplyr::summarize(download_total = sum(count))
 
-cran_stats <- cran %>% 
-  separate(date, into=c("year", "month name", "day"), sep = "-") %>% 
+cran_stats <- cran %>%
+  separate(date, into=c("year", "month name", "day"), sep = "-") %>%
   unite("Month", c("year", "month name"), sep='-', remove=TRUE) %>%  
-  group_by(Month, package) %>% 
+  group_by(Month, package) %>%
   summarise(monthly_downloads = sum(count)) %>% #summarize monthly downloads by package
-  filter(monthly_downloads > 0) #drop the 0's 
+  filter(monthly_downloads > 0) #drop the 0's
 
-ggplot(cran_stats, aes(Month, monthly_downloads, group=package, color = package)) + 
-  geom_line() + 
+ggplot(cran_stats, aes(Month, monthly_downloads, group=package, color = package)) +
+  geom_line() +
   geom_point() +
   theme(panel.background = element_blank(), panel.grid = element_blank()) +
   theme(axis.text.x = element_text(angle = 90)) +

--- a/cran.Rmd
+++ b/cran.Rmd
@@ -62,3 +62,12 @@ cran_googlesheet:
 - [ ] In the `config_automation.yml` file, make sure that `refresh-cran` is set to "yes".
 - [ ] In the `cran_packages` of your `config_automation.yml`, type the names of the packages that you'd like to collect data from on CRAN. Type them exactly as they are spelled, case sensitive, separated by commas. Delete the example package names we've put there.
 - [ ] Optionally, if you are saving data to google, specify a googlesheet ID in `cran_googlesheet` you'd like the CRAN data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+## Customizing CRAN Data 
+
+In order to customize the data you are downloading from CRAN you can modify the 
+`refresh-scripts/refresh-cran.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/cran.Rmd
+++ b/cran.Rmd
@@ -2,9 +2,9 @@
 title: "CRAN"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/docs/github.html
+++ b/docs/github.html
@@ -13,7 +13,7 @@
 
 <title>GitHub</title>
 
-<script src="site_libs/header-attrs-2.25/header-attrs.js"></script>
+<script src="site_libs/header-attrs-2.26/header-attrs.js"></script>
 <script src="site_libs/jquery-3.6.0/jquery-3.6.0.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/cosmo.min.css" rel="stylesheet" />
@@ -315,25 +315,79 @@ $(document).ready(function () {
 
 <div id="preview" class="section level2">
 <h2>Preview</h2>
-<pre><code>## Rows: 2 Columns: 6
-## ── Column specification ────────────────────────────────────────────────────────
-## Delimiter: &quot;\t&quot;
-## chr (1): repo_name
-## dbl (4): num_contributors, total_contributions, num_stars, health_percentage
-## lgl (1): num_forks
-## 
-## ℹ Use `spec()` to retrieve the full column specification for this data.
-## ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
-## Rows: 12 Columns: 6
-## ── Column specification ────────────────────────────────────────────────────────
-## Delimiter: &quot;\t&quot;
-## chr  (1): repo
-## dbl  (4): count_clones, uniques_clones, count_views, uniques_views
-## date (1): timestamp
-## 
-## ℹ Use `spec()` to retrieve the full column specification for this data.
-## ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.</code></pre>
-<pre class="r"><code>knitr::kable(github)</code></pre>
+<p>Contributions to a repository example:</p>
+<p><img src="github_files/figure-html/unnamed-chunk-2-1.png" width="672" /></p>
+<p>Views of a GitHub Repository over time</p>
+<pre><code>## Warning: Removed 2 rows containing missing values or values outside the scale range
+## (`geom_line()`).</code></pre>
+<p><img src="github_files/figure-html/unnamed-chunk-3-1.png" width="672" /></p>
+</div>
+<div id="data-information" class="section level2">
+<h2>Data information</h2>
+<p>Data information for <code>github overall data</code>:</p>
+<ul>
+<li><code>num_forks</code> shows the number of times this repo has been
+forked. NA means it has never been forked.</li>
+<li><code>num_contributors</code> how many people have contributed to
+this repo</li>
+<li><code>num_stars</code> how many people have starred this repo?</li>
+<li><code>health_percentage</code> what percentage of <a
+href="https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories">“good
+software health” items as described by GitHub</a> does this repo
+have?</li>
+</ul>
+<pre class="r"><code>knitr::kable(github_overall)</code></pre>
+<table style="width:100%;">
+<colgroup>
+<col width="22%" />
+<col width="10%" />
+<col width="17%" />
+<col width="20%" />
+<col width="10%" />
+<col width="18%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">repo_name</th>
+<th align="left">num_forks</th>
+<th align="right">num_contributors</th>
+<th align="right">total_contributions</th>
+<th align="right">num_stars</th>
+<th align="right">health_percentage</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">fhdsl/metricminer</td>
+<td align="left">NA</td>
+<td align="right">4</td>
+<td align="right">432</td>
+<td align="right">1</td>
+<td align="right">37</td>
+</tr>
+<tr class="even">
+<td align="left">fhdsl/metricminer.org</td>
+<td align="left">NA</td>
+<td align="right">2</td>
+<td align="right">28</td>
+<td align="right">0</td>
+<td align="right">37</td>
+</tr>
+</tbody>
+</table>
+<p>Data information for <code>github timecourse</code>:</p>
+<ul>
+<li><code>timestampe</code> shows the date the counts correspond to</li>
+<li><code>count_clones</code> tells the number of clones made on this
+day</li>
+<li><code>unique_clones</code> tells how many people did these clones
+come from?</li>
+<li><code>count_views</code> how many views did the repo get on this
+day?</li>
+<li><code>unique_views</code> how many people were those views
+from?</li>
+</ul>
+<pre class="r"><code>knitr::kable(github_timecourse)</code></pre>
 <table>
 <colgroup>
 <col width="25%" />

--- a/github.Rmd
+++ b/github.Rmd
@@ -6,7 +6,7 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE, message=FALSE}
+```{r, echo = FALSE, hide = TRUE, message=FALSE, warning = FALSE}
 library(ggplot2)
 library(magrittr)
 
@@ -24,7 +24,7 @@ github_timecourse <- readr::read_tsv(file.path("metricminer_data", "github", "gi
 
 Contributions to a repository example:
 
-```{r echo = FALSE, hide = TRUE, message=FALSE}
+```{r echo = FALSE, hide = TRUE, message=FALSE, warning = FALSE}
 github_overall %>% 
   ggplot(aes(x = repo_name, y = total_contributions)) + 
   geom_bar(stat = "identity", fill = "lavender") + 

--- a/github.Rmd
+++ b/github.Rmd
@@ -7,6 +7,9 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 ## Preview
 
 ```{r, echo = FALSE, hide = TRUE, message=FALSE}
+library(ggplot2)
+library(magrittr)
+
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 
@@ -19,6 +22,24 @@ github_timecourse <- readr::read_tsv(file.path("metricminer_data", "github", "gi
 # github_timecourse <- googlesheets4::read_sheet(yaml$github_googlesheet, sheet = "timecourse")
 ```
 
+Contributions to a repository example:
+
+```{r echo = FALSE, hide = TRUE, message=FALSE}
+github_overall %>% 
+  ggplot(aes(x = repo_name, y = total_contributions)) + 
+  geom_bar(stat = "identity", fill = "lavender") + 
+  theme_classic()
+```
+
+Views of a GitHub Repository over time 
+
+```{r echo = FALSE, hide = TRUE, message=FALSE}
+github_timecourse %>% 
+  ggplot(aes(x = timestamp, y = count_views, fill = repo, color = repo)) + 
+  geom_line(stat = "identity") + 
+  theme_classic() + 
+  ylab("date")
+```
 
 ## Data information 
 

--- a/github.Rmd
+++ b/github.Rmd
@@ -6,19 +6,43 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE}
+```{r, echo = FALSE, hide = TRUE, message=FALSE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 
 ## For github
-github <- readr::read_tsv(file.path("metricminer_data", "github", "github.tsv"))
-github <- readr::read_tsv(file.path("metricminer_data", "github", "github_timecourse.tsv"))
+github_overall <- readr::read_tsv(file.path("metricminer_data", "github", "github.tsv"))
+github_timecourse <- readr::read_tsv(file.path("metricminer_data", "github", "github_timecourse.tsv"))
 
-## For google 
-# github <- googlesheets4::read_sheet(yaml$github_googlesheet)
+## For google
+# github_overall <- googlesheets4::read_sheet(yaml$github_googlesheet, sheet = "overall_stats")
+# github_timecourse <- googlesheets4::read_sheet(yaml$github_googlesheet, sheet = "timecourse")
 ```
-```{r}
-knitr::kable(github)
+
+
+## Data information 
+
+Data information for `github overall data`:
+
+- `num_forks` shows the number of times this repo has been forked. NA means it has never been forked. 
+- `num_contributors` how many people have contributed to this repo
+- `num_stars` how many people have starred this repo?
+- `health_percentage` what percentage of ["good software health" items as described by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories) does this repo have? 
+
+```{r, message=FALSE}
+knitr::kable(github_overall)
+```
+
+Data information for `github timecourse`:
+
+- `timestampe` shows the date the counts correspond to
+- `count_clones` tells the number of clones made on this day 
+- `unique_clones` tells how many people did these clones come from?
+- `count_views` how many views did the repo get on this day?
+- `unique_views` how many people were those views from?
+
+```{r, message=FALSE}
+knitr::kable(github_timecourse)
 ```
 
 ### Setting up GitHub

--- a/github.Rmd
+++ b/github.Rmd
@@ -1,7 +1,12 @@
 ---
 title: "GitHub"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
+
 ---
 
 ## Preview
@@ -56,11 +61,11 @@ knitr::kable(github_overall)
 
 Data information for `github timecourse`:
 
-- `timestampe` shows the date the counts correspond to
-- `count_clones` tells the number of clones made on this day 
-- `unique_clones` tells how many people did these clones come from?
-- `count_views` how many views did the repo get on this day?
-- `unique_views` how many people were those views from?
+- `timestamp` shows the date the counts correspond to
+- `count_clones` tells the number of clones made on this day. NAs generally indicate no one cloned the repository that day. 
+- `unique_clones` tells how many people did these clones come from? NAs generally indicate no one cloned the repository that day.
+- `count_views` how many views did the repo get on this day? NAs generally indicate no one viewed the repository that date
+- `unique_views` how many people were those views from? NAs generally indicate no one viewed the repository that date
 
 ```{r, message=FALSE}
 knitr::kable(github_timecourse)

--- a/github.Rmd
+++ b/github.Rmd
@@ -2,9 +2,9 @@
 title: "GitHub"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ---
@@ -71,7 +71,7 @@ Data information for `github timecourse`:
 knitr::kable(github_timecourse)
 ```
 
-### Setting up GitHub
+## Setting up GitHub
 
 At this point you should already have your GitHub authorization set up for your metricminer dashboard by having [followed the instructions above.](#setting-up-your-dashboard-repository).
 

--- a/github.Rmd
+++ b/github.Rmd
@@ -86,3 +86,12 @@ github_googlesheet:
 - [ ] In the `_config_automation.yml` file, make sure that `refresh-github` is set to "yes".
 - [ ] In `github_repos` of your `_config_automation.yml`, specify the names of the repositories you'd like to collect data from in `github_repos`. Make sure it includes the `owner/repository` e.g. `fhdsl/metricminer` not just `metricminer`. Commas need to separate the repositories. Delete the example repositories we put there.
 - [ ] Optionally, if you are saving data to Google, specify a googlesheet ID in `github_googlesheet` you'd like the GitHub data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+## Customizing GitHub Data 
+
+In order to customize the data you are downloading from GitHub you can modify the 
+`refresh-scripts/refresh-github.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/googleanalytics.Rmd
+++ b/googleanalytics.Rmd
@@ -2,9 +2,9 @@
 title: "Google Analytics"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -42,7 +42,7 @@ knitr::kable(ga_dimensions)
 knitr::kable(ga_link_clicks)
 ```
 
-### Setting up Google Analytics
+## Setting up Google Analytics
 
 [Follow the steps from the above section to authenticate Google](#setting-up-google-authentication) -- make sure that the account you have authenticated for has access to the Google Analytics properties you wish to collect.
 

--- a/googleanalytics.Rmd
+++ b/googleanalytics.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "Google Analytics"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -8,7 +12,7 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE}
+```{r, echo = FALSE, hide = TRUE, message = FALSE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 

--- a/googleanalytics.Rmd
+++ b/googleanalytics.Rmd
@@ -70,3 +70,13 @@ ga_googlesheet:
 
 - [ ] In the `config_automation.yml` file, make sure that `refresh-ga` is set to "yes".
 - [ ] Optionally, if you are saving data to Google, specify a googlesheet ID in `ga_googlesheet` you'd like the GitHub data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+
+## Customizing the data 
+
+In order to customize the data you are downloading from Google Analytics you can modify the 
+`refresh-scripts/refresh-ga.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/googleforms.Rmd
+++ b/googleforms.Rmd
@@ -48,3 +48,12 @@ googleforms_googlesheet:
 
 - [ ] In the `config_automation.yml` file, make sure that `refresh-googleforms` is set to "yes".
 - [ ] Optionally, if you are saving data to Google, specify a googlesheet ID in `googleforms_googlesheet` you'd like the GitHub data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+## Customizing the Google Forms Data 
+
+In order to customize the data you are downloading from your Google Forms you can modify the 
+`refresh-scripts/refresh-googleforms.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/googleforms.Rmd
+++ b/googleforms.Rmd
@@ -2,9 +2,9 @@
 title: "Google Forms"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/googleforms.Rmd
+++ b/googleforms.Rmd
@@ -1,12 +1,16 @@
 ---
 title: "Google Forms"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE}
+```{r, echo = FALSE, hide = TRUE, message = FALSE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 

--- a/slido.Rmd
+++ b/slido.Rmd
@@ -2,9 +2,9 @@
 title: "Slido"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -21,7 +21,7 @@ polls <- readr::read_tsv(file.path("metricminer_data", "slido", "Polls-overall.t
 questions <- readr::read_tsv(file.path("metricminer_data", "slido", "Questions.tsv"))
 ```
 
-### Setting up Slido
+## Setting up Slido
 
 This is assuming you have already exported Slido data to a google drive folder. See [Slido instructions here](https://community.slido.com/analytics-and-exports-44/export-your-questions-poll-results-quiz-leaderboard-and-ideas-532) for how to do that. Navigate to the Google Drive folder that has the Slidos you'd like to collect. Get the URL for this folder. It should look like this:
 

--- a/slido.Rmd
+++ b/slido.Rmd
@@ -39,3 +39,12 @@ slido_googlesheet:
 
 - [ ] In the `config_automation.yml` file, make sure that `refresh-slido` is set to "yes".
 - [ ] Optionally, if you are saving data to Google, specify a googlesheet ID in `slido_googlesheet` that you'd like the GitHub data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+## Customizing the Slido Data 
+
+In order to customize the data you are downloading from your Slido you can modify the 
+`refresh-scripts/refresh-slido.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 

--- a/slido.Rmd
+++ b/slido.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "Slido"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 

--- a/youtube.Rmd
+++ b/youtube.Rmd
@@ -1,12 +1,16 @@
 ---
 title: "YouTube"
-output: html_document
+output: 
+  html_document:
+  toc: true
+  toc_float: true
+  toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE}
+```{r, echo = FALSE, hide = TRUE, message = FALSE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 
@@ -15,6 +19,14 @@ youtube <- readr::read_tsv(file.path("metricminer_data", "youtube", "youtube.tsv
 
 ## For youtube
 ```
+
+## Data information 
+
+- `viewCount` how many times has the video been viewed?
+- `likeCount` how many times has the video been liked?
+- `dislikeCount` - how many times has the video been disliked?
+- `favoriteCount` - how many times has the video been favorited?
+- `commentCount` - how many comments on the video?
 
 ```{r}
 knitr::kable(youtube)

--- a/youtube.Rmd
+++ b/youtube.Rmd
@@ -2,9 +2,9 @@
 title: "YouTube"
 output: 
   html_document:
-  toc: true
-  toc_float: true
-  toc_collapsed: true
+    toc: true
+    toc_float: true
+    toc_collapsed: true
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
 
@@ -32,7 +32,7 @@ youtube <- readr::read_tsv(file.path("metricminer_data", "youtube", "youtube.tsv
 knitr::kable(youtube)
 ```
 
-### Setting up YouTube
+## Setting up YouTube
 
 [Follow the steps from the above section to authenticate Google](#setting-up-google-authentication) -- make sure that the account you have authenticated for has access to the YouTube you wish to collect.
 

--- a/youtube.Rmd
+++ b/youtube.Rmd
@@ -10,7 +10,7 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 
 ## Preview
 
-```{r, echo = FALSE, hide = TRUE, message = FALSE}
+```{r, echo = FALSE, hide = TRUE, message = FALSE, warning = FALSE}
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 yaml <- yaml::read_yaml(file.path(root_dir, "_config_automation.yml"))
 
@@ -52,3 +52,12 @@ youtube_googlesheet:
 
 - [ ] In the `config_automation.yml` file, make sure that `refresh-slido` is set to "yes".
 - [ ] Optionally, if you are saving data to Google, specify a googlesheet ID in `youtube_googlesheet` that you'd like the GitHub data to be saved to. This will only be relevant if you've set `data_dest` to `google`.
+
+## Customizing the YouTube Data 
+
+In order to customize the data you are downloading from your YouTube you can modify the 
+`refresh-scripts/refresh-youtube.R` script in your repository. 
+
+You can take a look at the [`metricminer` R package documentation](https://hutchdatascience.org/metricminer/articles/getting-started.html) for more details about the functions and what is possible. 
+
+If you have a metric need that is not currently fulfilled by `metricminer` or `metricminer-dashboard` we encourage you to [file a GitHub issue with us and let us know about your new feature idea (or bug report)](https://github.com/fhdsl/metricminer/issues/new/choose). 


### PR DESCRIPTION
<!-- From https://axolo.co/blog/p/part-3-github-pull-request-template--> 

# Description

This is adding plots and info for the github data examples. Related to #6 

I added plots for the github stuff but also adding more repos that we can pull from. 


I'm also adding here some standard structure items for each page. I think each page should have a structure like this: 

1) Preview - snazzy plot that shows a preview of what the data could look like 
2) Data Information - Table that shows what data are available 
3) Setting up - How we actually go about setting it up
4) Customization -- what if the data you want isn't there? How to customize