### PR TITLE
config and documentation updates

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -17,20 +17,9 @@ group:
         dest: .github/workflows/render-site.yml
       - source: .github/workflows/pull_request.yml
         dest: .github/workflows/pull_request.yml
-      - source: _config_automation.yml
-        dest: _config_automation.yml
   # Repositories to receive changes
     repos: |
-      jhudsl/ottr-website
-      jhudsl/Baltimore_Community_Course
-      maculatus/test-ottr-website
-      dr-sayyadhury/OTTR_Template_Website_repo
-      whalera1901/Current-projects
-      GenetcXBiotech1/Dr.Fierst_lab
-      buriedsand/glbio-personal-website
-      PurplFeesh/test-ottr-site
-      jcha40/ottr_test_site
-      jhudsl/ITCR_Tables
+      opencasestudies/ocs-metrics-dashboard
 ###ADD NEW REPO HERE following the format above#
 
 ### These are custom groups for syncing -- not all files needs to be synced # will update later

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository is a template dashboard website for you to display metrics mined
 6. Return to your metricminer dashboard repository and go to Settings > Secrets and variables > Actions.
 7. Click on `New repository secret`. Name your new secret *exactly* `METRICMINER_GITHUB_PAT`
 8. Copy and paste your Personal access token in the `Secret` box and then click the green "Add secret" button.
+9. Sign up for template syncs by adding your repository to [the sync list](https://github.com/fhdsl/metricminer-dashboard/blob/main/.github/sync.yml).
+10. Note: If metricminer adds new functionality that you want to incorporate, you will need to add it to your `_config_automation.yml` file manually since that file isn't included in template syncs.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
Removed the config file from the list of files that will be updated in syncs (so people's configurations aren't wiped out) (as discussed in today's meeting and mentioned in issue #26)

Added the ocs-metrics-dashboard to the list of repos to receive syncs

Removed repos that were listed in the OTTR Template Website sync list from the list of repos to receive syncs

Updated the README to include info about the sync and config file (as discussed in today's meeting and mentioned in issue #26)